### PR TITLE
Removes timestamp from custom ID generation

### DIFF
--- a/src/python/anthropic_batch_request_util/batch_handler.py
+++ b/src/python/anthropic_batch_request_util/batch_handler.py
@@ -618,12 +618,11 @@ class AnthropicBatchHandler:
                 raise ValidationError("Invalid custom_id_prefix")
 
             requests = []
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
             for i, messages in enumerate(messages_list):
                 try:
                     # Generate unique custom ID for each request
-                    custom_id = f"{custom_id_prefix}_{timestamp}_{i}"
+                    custom_id = f"{custom_id_prefix}_{i}"
 
                     # Build request using utility method
                     request = self.util.build_request_payload(


### PR DESCRIPTION
Simplifies custom ID creation by eliminating the timestamp, resulting in a more straightforward and predictable format.

This adjustment enhances the clarity of generated IDs by limiting them to the custom prefix and request index.